### PR TITLE
Set working directory for update-deps job

### DIFF
--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -3,11 +3,14 @@ name: Auto Update Dependencies
 on:
   schedule:
     - cron: "0 0 * * *" # Runs every day at midnight UTC
-  workflow_dispatch: # Allow manual trigger
+  workflow_dispatch:
 
 jobs:
   update-deps:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: web
 
     steps:
       # 1. Checkout repository


### PR DESCRIPTION
Added a defaults.run.working-directory setting to the update-deps job in the GitHub Actions workflow, ensuring all steps execute in the 'web' directory.